### PR TITLE
when no face found in image, return success message

### DIFF
--- a/src/AnalysisLayer/Vision/intelligencelayer/face.py
+++ b/src/AnalysisLayer/Vision/intelligencelayer/face.py
@@ -485,7 +485,7 @@ def recognise_face(_: CodeProjectAIRunner, data: AIRequestData) -> JSON:
 
         if found_face == False:
 
-            output = {"success": False, "error": "No face found in image"}
+            output = {"success": True, "predictions": [], "message": "No face found in image"}
 
         elif len(facemap) == 0:
 


### PR DESCRIPTION
when no face found in image, return success message with empty array and message explain no face found (same as 'No known faces')