### PR TITLE
Bugfix: incorrect standard ports in service URL

### DIFF
--- a/src/server/wwwroot/assets/server.js
+++ b/src/server/wwwroot/assets/server.js
@@ -13,7 +13,7 @@ if (!apiServiceProtocol || apiServiceProtocol === "file:")
     apiServiceProtocol = "http:"; // Needed if you launch this file from Finder
 
 const apiServiceHostname = window.location.hostname || "localhost";
-const apiServicePort     = ":" + (window.location.port || 32168);
+const apiServicePort     = window.location.port === "" ? "" : ":" + (window.location.port || 32168);
 const apiServiceUrl      = `${apiServiceProtocol}//${apiServiceHostname}${apiServicePort}`;
 
 // Private vars


### PR DESCRIPTION
Corrected an issue where, when using standard ports (80 for HTTP and 443 for HTTPS), the page incorrectly tried to connect to port 32168 instead.