### PR TITLE
add prometheus metrics

### DIFF
--- a/src/server/Server.csproj
+++ b/src/server/Server.csproj
@@ -87,6 +87,7 @@ https://learn.microsoft.com/en-us/visualstudio/msbuild/property-functions?view=v
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="7.0.0" />
+		<PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/server/Startup.cs
+++ b/src/server/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using Prometheus;
 
 /*
 #if Windows
@@ -175,9 +176,16 @@ namespace CodeProject.AI.Server
 
             app.UseRouting();
 
+            app.UseHttpMetrics();
+
             app.UseCors("allowAllOrigins");
 
             app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapMetrics();
+            });
 
             app.UseEndpoints(endpoints =>
             {


### PR DESCRIPTION
adds simple prometheus metrics for http routes and the default metrics endpoint for prometheus to scrape